### PR TITLE
Version 0.1 (Refactored)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016-2017 Dhii
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Espresso Interface
+# Expression Interface
 
 [![Build Status](https://travis-ci.org/Dhii/espresso-interface.svg?branch=master)](https://travis-ci.org/Dhii/espresso-interface)
 [![Code Climate](https://codeclimate.com/github/Dhii/espresso-interface/badges/gpa.svg)](https://codeclimate.com/github/Dhii/espresso-interface)
 [![Test Coverage](https://codeclimate.com/github/Dhii/espresso-interface/badges/coverage.svg)](https://codeclimate.com/github/Dhii/espresso-interface/coverage)
 
-This repository contains the interfaces for Espresso: a library for representing expressions as tree structures and evaluating them using contexts.
+This package consists of a set of interoperable interfaces for representing expressions.
 
 # Requirements
 
@@ -13,5 +13,5 @@ This repository contains the interfaces for Espresso: a library for representing
 # Installation
 
 ```
-composer require dhii/espresso-interface
+composer require dhii/expression-interface
 ```

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": "^5.3.9 | ^7.0",
+        "php": "^5.3 | ^7.0",
         "dhii/evaluable-interface": "^0.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "dhii/espresso-interface",
-    "description": "The interfaces for Espresso: a PHP expression builder and evaluation library.",
+    "description": "Interoperable interfaces for representing expressions.",
     "type": "library",
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Dhii\\Espresso\\": "src/"
+            "Dhii\\Expression\\": "src/"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "dhii/espresso-interface",
+    "name": "dhii/expression-interface",
     "description": "Interoperable interfaces for representing expressions.",
     "type": "library",
     "license": "MIT",

--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -1,7 +1,7 @@
-file.reference.espresso-interface-vendor=vendor
+file.reference.expression-interface-vendor=vendor
 include.path=\
     ${php.global.include.path}:\
-    ${file.reference.espresso-interface-vendor}
+    ${file.reference.expression-interface-vendor}
 php.version=PHP_53
 source.encoding=UTF-8
 src.dir=src

--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -1,3 +1,16 @@
+auxiliary.org-netbeans-modules-php-phpunit.bootstrap_2e_create_2e_tests=false
+auxiliary.org-netbeans-modules-php-phpunit.bootstrap_2e_enabled=true
+auxiliary.org-netbeans-modules-php-phpunit.bootstrap_2e_path=test/bootstrap.php
+auxiliary.org-netbeans-modules-php-phpunit.configuration_2e_enabled=true
+auxiliary.org-netbeans-modules-php-phpunit.configuration_2e_path=phpunit.xml
+auxiliary.org-netbeans-modules-php-phpunit.customSuite_2e_enabled=false
+auxiliary.org-netbeans-modules-php-phpunit.customSuite_2e_path=
+auxiliary.org-netbeans-modules-php-phpunit.phpUnit_2e_enabled=false
+auxiliary.org-netbeans-modules-php-phpunit.phpUnit_2e_path=
+auxiliary.org-netbeans-modules-php-phpunit.test_2e_groups_2e_ask=false
+auxiliary.org-netbeans-modules-php-phpunit.test_2e_run_2e_all=false
+auxiliary.org-netbeans-modules-php-phpunit.test_2e_run_2e_phpunit_2e_only=true
+file.reference.expression-interface-test=test
 file.reference.expression-interface-vendor=vendor
 include.path=\
     ${php.global.include.path}:\
@@ -7,4 +20,6 @@ source.encoding=UTF-8
 src.dir=src
 tags.asp=false
 tags.short=false
+test.src.dir=${file.reference.expression-interface-test}
+testing.providers=PhpUnit
 web.root=.

--- a/nbproject/project.xml
+++ b/nbproject/project.xml
@@ -3,7 +3,7 @@
     <type>org.netbeans.modules.php.project</type>
     <configuration>
         <data xmlns="http://www.netbeans.org/ns/php-project/1">
-            <name>dhii - espresso-interface</name>
+            <name>dhii - expression-interface</name>
         </data>
     </configuration>
 </project>

--- a/src/CompositeContextInterface.php
+++ b/src/CompositeContextInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Dhii\Espresso;
+namespace Dhii\Expression;
 
 /**
  * A context with multiple values.

--- a/src/ContextInterface.php
+++ b/src/ContextInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Dhii\Espresso;
+namespace Dhii\Expression;
 
 use Dhii\Data\ValueAwareInterface;
 

--- a/src/ContextInterface.php
+++ b/src/ContextInterface.php
@@ -11,12 +11,4 @@ use Dhii\Data\ValueAwareInterface;
  */
 interface ContextInterface extends ValueAwareInterface
 {
-    /**
-     * Gets the context-specific value.
-     *
-     * @since 0.1
-     *
-     * @return mixed The contextual value.
-     */
-    public function getValue();
 }

--- a/src/ExpressionInterface.php
+++ b/src/ExpressionInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Dhii\Espresso;
+namespace Dhii\Expression;
 
 use Dhii\Evaluable\EvaluableInterface;
 

--- a/src/LogicalExpressionInterface.php
+++ b/src/LogicalExpressionInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Dhii\Espresso;
+namespace Dhii\Expression;
 
 /**
  * A logical expression is an expression that evaluates to either true or false.

--- a/test/functional/CompositeContextInterfaceTest.php
+++ b/test/functional/CompositeContextInterfaceTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Dhii\Espresso\Test;
+namespace Dhii\Expression\Test;
 
-use \Dhii\Espresso\CompositeContextInterface;
+use \Dhii\Expression\CompositeContextInterface;
 use \Xpmock\TestCase;
 
 /**
- * Tests {@see \Dhii\Espresso\CompositeContextInterface}.
+ * Tests {@see \Dhii\Expression\CompositeContextInterface}.
  *
  * @since 0.1
  */
@@ -17,7 +17,7 @@ class CompositeContextInterfaceTest extends TestCase
      *
      * @since 0.1
      */
-    const TEST_SUBJECT_CLASSNAME = '\\Dhii\\Espresso\\CompositeContextInterface';
+    const TEST_SUBJECT_CLASSNAME = '\\Dhii\\Expression\\CompositeContextInterface';
 
     /**
      * Creates a new instance of the test subject.
@@ -40,7 +40,7 @@ class CompositeContextInterfaceTest extends TestCase
     /**
      * Tests whether a valid instance of the test subject can be created.
      *
-     * @covers \Dhii\Espresso\CompositeContextInterface
+     * @covers \Dhii\Expression\CompositeContextInterface
      *
      * @since 0.1
      */
@@ -49,6 +49,6 @@ class CompositeContextInterfaceTest extends TestCase
         $subject = $this->createInstance();
 
         $this->assertInstanceOf(static::TEST_SUBJECT_CLASSNAME, $subject);
-        $this->assertInstanceOf('Dhii\\Espresso\\ContextInterface', $subject);
+        $this->assertInstanceOf('Dhii\\Expression\\ContextInterface', $subject);
     }
 }

--- a/test/functional/ContextInterfaceTest.php
+++ b/test/functional/ContextInterfaceTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Dhii\Espresso\Test;
+namespace Dhii\Expression\Test;
 
-use \Dhii\Espresso\ContextInterface;
+use \Dhii\Expression\ContextInterface;
 use \Xpmock\TestCase;
 
 /**
- * Tests {@see \Dhii\Espresso\ContextInterface}.
+ * Tests {@see \Dhii\Expression\ContextInterface}.
  *
  * @since 0.1
  */
@@ -17,7 +17,7 @@ class ContextInterfaceTest extends TestCase
      *
      * @since 0.1
      */
-    const TEST_SUBJECT_CLASSNAME = '\\Dhii\\Espresso\\ContextInterface';
+    const TEST_SUBJECT_CLASSNAME = '\\Dhii\\Expression\\ContextInterface';
 
     /**
      * Creates a new instance of the test subject.
@@ -38,7 +38,7 @@ class ContextInterfaceTest extends TestCase
     /**
      * Tests whether a valid instance of the test subject can be created.
      *
-     * @covers \Dhii\Espresso\ContextInterface
+     * @covers \Dhii\Expression\ContextInterface
      *
      * @since 0.1
      */

--- a/test/functional/ExpressionInterfaceTest.php
+++ b/test/functional/ExpressionInterfaceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Dhii\Espresso\Test;
+namespace Dhii\Expression\Test;
 
 /**
  * Tests {@see \Dhii\ExpressionInterface}.
@@ -15,14 +15,14 @@ class ExpressionInterfaceTest extends \Xpmock\TestCase
      *
      * @since 0.1
      */
-    const TEST_SUBJECT_CLASSNAME = '\\Dhii\\Espresso\\ExpressionInterface';
+    const TEST_SUBJECT_CLASSNAME = '\\Dhii\\Expression\\ExpressionInterface';
 
     /**
      * Creates a new instance of the test subject.
      *
      * @since 0.1
      *
-     * @return \Dhii\Espresso\ExpressionInterface
+     * @return \Dhii\Expression\ExpressionInterface
      */
     public function createInstance()
     {
@@ -37,7 +37,7 @@ class ExpressionInterfaceTest extends \Xpmock\TestCase
     /**
      * Tests whether a valid instance of the test subject can be created.
      *
-     * @covers \Dhii\Espresso\ExpressionInterface
+     * @covers \Dhii\Expression\ExpressionInterface
      *
      * @since 0.1
      */

--- a/test/functional/LogicalExpressionInterfaceTest.php
+++ b/test/functional/LogicalExpressionInterfaceTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Dhii\Espresso\Test;
+namespace Dhii\Expression\Test;
 
 /**
- * Tests {@see \Dhii\Espresso\LogicalExpressionInterface}.
+ * Tests {@see \Dhii\Expression\LogicalExpressionInterface}.
  *
  * @since [*next-version*]
  */
@@ -15,14 +15,14 @@ class LogicalExpressionInterfaceTest extends \Xpmock\TestCase
      *
      * @since 0.1
      */
-    const TEST_SUBJECT_CLASSNAME = 'Dhii\\Espresso\\LogicalExpressionInterface';
+    const TEST_SUBJECT_CLASSNAME = 'Dhii\\Expression\\LogicalExpressionInterface';
 
     /**
      * Creates a new instance of the test subject.
      *
      * @since 0.1
      *
-     * @return \Dhii\Espresso\LogicalExpressionInterface
+     * @return \Dhii\Expression\LogicalExpressionInterface
      */
     public function createInstance()
     {
@@ -45,7 +45,7 @@ class LogicalExpressionInterfaceTest extends \Xpmock\TestCase
         $subject = $this->createInstance();
 
         $this->assertInstanceOf(static::TEST_SUBJECT_CLASSNAME, $subject);
-        $this->assertInstanceOf('Dhii\\Espresso\\ExpressionInterface', $subject);
+        $this->assertInstanceOf('Dhii\\Expression\\ExpressionInterface', $subject);
         $this->assertInstanceOf('Dhii\\Evaluable\\EvaluableInterface', $subject);
     }
 


### PR DESCRIPTION
Following pull request #1, the package [has been refactored][5] from `dhii/espresso-interface` to `dhii/expression-interface`.

This also means the [namespace has changed][4] from `Dhii\Espresso` to `Dhii\Expression`. The [package description has also been updated][1] to reflect the fact that this repository is no longer directly related to the Espresso implementation.

Apart from that, the [`ContextInterface#getValue()` method has been removed][2] due to unneeded redundancy. As a consequence, the [PHP version has been lowered][3] from `5.3.9` to `5.3`.

[1]: https://github.com/Dhii/espresso-interface/pull/2/commits/4f040b2e5ef4ac98bd2ac7f3d077d7bf5ee874e7
[2]: https://github.com/Dhii/espresso-interface/pull/2/commits/c6e343a2fa251142a086bca7f0990aef343f29bc
[3]: https://github.com/Dhii/espresso-interface/pull/2/commits/c07aebdff0eabe8c6fea3adeca3e3719a6781e42
[4]: https://github.com/Dhii/espresso-interface/pull/2/commits/f666c81b955a95a443c8a5053e350f2e088c9517
[5]: https://github.com/Dhii/espresso-interface/pull/2/commits/d8eafb310500ae03dacc9eeabc9c53965d84964f